### PR TITLE
Close resize pool thread when main thread finishes

### DIFF
--- a/pymysqlpool/pool.py
+++ b/pymysqlpool/pool.py
@@ -120,9 +120,11 @@ class Pool(object):
 
     def _start(self):
         """Start thread for resize pool"""
-        t = Thread(target=resize_pool, args=(self.interval, self.stati_num,
-                                             self.multiple, self.counter,
-                                             self.accumulation, self))
+        t = Thread(target=resize_pool,
+                   args=(self.interval, self.stati_num,
+                         self.multiple, self.counter,
+                         self.accumulation, self),
+                   daemon=True)
         t.start()
 
     def _init_pool(self):


### PR DESCRIPTION
If we don't mark the resize pool thread as daemon, it keeps running even after the main thread is finished. This keeps the process from exiting.